### PR TITLE
fix: allow empty dict

### DIFF
--- a/getschema/impl.py
+++ b/getschema/impl.py
@@ -265,7 +265,7 @@ def fix_type(obj, schema, dict_path=[], on_invalid_property="raise",
 
     # Recurse if object or array types
     if obj_type == "object":
-        if not (type(obj) is dict and obj.keys()):
+        if type(obj) is not dict:
             raise KeyError("property type (object) Expected a dict object." +
                            "Got: %s %s" % (type(obj), str(obj)))
         cleaned = dict()


### PR DESCRIPTION
fixes issue #1 

Manually tested with
https://raw.githubusercontent.com/anelendata/tap-rest-api/master/examples/usgs/sample_records.json
By removing the properties of geometry.

The fix allows empty dict.