### PR TITLE
Fixed bug in detecting datetime fields.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 install_test
-Pipfile
-Pipfile.lock
-pyproject.toml
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 install_test
+Pipfile
+Pipfile.lock
+pyproject.toml
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/getschema/impl.py
+++ b/getschema/impl.py
@@ -76,7 +76,7 @@ def _do_infer_schema(obj, record_level=None, lower=False,
     else:
         try:
             float(obj)
-        except ValueError:
+        except (ValueError, TypeError):
             schema["type"] = ["null", "string"]
             if _is_datetime(obj):
                 schema["format"] = "date-time"


### PR DESCRIPTION
Fixes a bug in schema inference where a `TypeError` is thrown when only a `ValueError` is currently expected:

```
[2021-06-14 13:08:11,027] {pod_launcher.py:136} INFO - meltano                       | CRITICAL float() argument must be a string or a number, not 'datetime.datetime'
[2021-06-14 13:08:11,027] {pod_launcher.py:136} INFO - meltano                       | Traceback (most recent call last):
[2021-06-14 13:08:11,027] {pod_launcher.py:136} INFO - meltano                       |   File "/code/.meltano/extractors/tap-bigquery-emarsys/venv/bin/tap-bigquery", line 8, in <module>
[2021-06-14 13:08:11,027] {pod_launcher.py:136} INFO - meltano                       |     sys.exit(main())
[2021-06-14 13:08:11,027] {pod_launcher.py:136} INFO - meltano                       |   File "/code/.meltano/extractors/tap-bigquery-emarsys/venv/lib/python3.7/site-packages/singer/utils.py", line 229, in wrapped
[2021-06-14 13:08:11,027] {pod_launcher.py:136} INFO - meltano                       |     return fnc(*args, **kwargs)
[2021-06-14 13:08:11,027] {pod_launcher.py:136} INFO - meltano                       |   File "/code/.meltano/extractors/tap-bigquery-emarsys/venv/lib/python3.7/site-packages/tap_bigquery/__init__.py", line 175, in main
[2021-06-14 13:08:11,028] {pod_launcher.py:136} INFO - meltano                       |     catalog = discover(CONFIG)
[2021-06-14 13:08:11,028] {pod_launcher.py:136} INFO - meltano                       |   File "/code/.meltano/extractors/tap-bigquery-emarsys/venv/lib/python3.7/site-packages/tap_bigquery/__init__.py", line 47, in discover
[2021-06-14 13:08:11,028] {pod_launcher.py:136} INFO - meltano                       |     stream)
[2021-06-14 13:08:11,028] {pod_launcher.py:136} INFO - meltano                       |   File "/code/.meltano/extractors/tap-bigquery-emarsys/venv/lib/python3.7/site-packages/tap_bigquery/sync_bigquery.py", line 101, in do_discover
[2021-06-14 13:08:11,028] {pod_launcher.py:136} INFO - meltano                       |     schema = getschema.infer_schema(data)
[2021-06-14 13:08:11,028] {pod_launcher.py:136} INFO - meltano                       |   File "/code/.meltano/extractors/tap-bigquery-emarsys/venv/lib/python3.7/site-packages/getschema/impl.py", line 220, in infer_schema
[2021-06-14 13:08:11,028] {pod_launcher.py:136} INFO - meltano                       |     o, record_level, lower, replace_special, snake_case)
[2021-06-14 13:08:11,028] {pod_launcher.py:136} INFO - meltano                       |   File "/code/.meltano/extractors/tap-bigquery-emarsys/venv/lib/python3.7/site-packages/getschema/impl.py", line 59, in _do_infer_schema
[2021-06-14 13:08:11,028] {pod_launcher.py:136} INFO - meltano                       |     ret = _do_infer_schema(obj[key])
[2021-06-14 13:08:11,028] {pod_launcher.py:136} INFO - meltano                       |   File "/code/.meltano/extractors/tap-bigquery-emarsys/venv/lib/python3.7/site-packages/getschema/impl.py", line 78, in _do_infer_schema
[2021-06-14 13:08:11,028] {pod_launcher.py:136} INFO - meltano                       |     float(obj)
[2021-06-14 13:08:11,028] {pod_launcher.py:136} INFO - meltano                       | TypeError: float() argument must be a string or a number, not 'datetime.datetime'
```